### PR TITLE
Iteration 0.2: socket activation, setup binary, instrumentation and better errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,23 +123,21 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-random"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
+checksum = "11df32a13d7892ec42d51d3d175faba5211ffe13ed25d4fb348ac9e9ce835593"
 dependencies = [
  "const-random-macro",
- "proc-macro-hack",
 ]
 
 [[package]]
 name = "const-random-macro"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
  "getrandom 0.2.10",
  "once_cell",
- "proc-macro-hack",
  "tiny-keccak",
 ]
 
@@ -162,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "dlv-list"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aead04dc46b5f263c25721cf25c9e595951d15055f8063f92392fa0d7f64cf4"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]
@@ -185,6 +198,18 @@ dependencies = [
  "lazy_static",
  "pwd",
 ]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "getrandom"
@@ -222,15 +247,15 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "indexmap"
@@ -239,7 +264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -262,9 +287,9 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -275,6 +300,15 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "memchr"
@@ -293,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -303,20 +337,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nm-proxy"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "byteorder",
  "expanduser",
  "libc",
- "log",
+ "nix",
  "rust-ini",
+ "sd-listen-fds",
  "serde",
  "serde_json",
  "tokio",
  "tokio-fd",
+ "tokio-util",
  "toml",
+ "tracing",
  "tracing-subscriber",
 ]
 
@@ -383,13 +431,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets",
 ]
@@ -399,12 +447,6 @@ name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -442,11 +484,11 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -459,6 +501,50 @@ dependencies = [
  "redox_syscall 0.1.57",
  "rust-argon2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rust-argon2"
@@ -501,6 +587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sd-listen-fds"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb51d45a99c1bafff550fd40ce1d2152917dc9908fb3090c283e3f058d39b3f"
+
+[[package]]
 name = "serde"
 version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -560,15 +652,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys",
@@ -587,18 +679,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -665,10 +757,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.2"
+name = "tokio-util"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef75d881185fd2df4a040793927c153d863651108a93c7e17a9e591baa95cc6"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -678,24 +783,46 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "380f9e8120405471f7c9ad1860a713ef5ece6a670c7eae39225e477340f32fc4"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -710,12 +837,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
@@ -725,10 +852,14 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nm-proxy"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Dennis Marttinen <twelho@welho.tech>"]
 description = "Native messaging proxy for Flatpak'ed browsers"
@@ -19,6 +19,10 @@ path = "src/client/main.rs"
 name = "daemon"
 path = "src/daemon/main.rs"
 
+[[bin]]
+name = "setup"
+path = "src/setup/main.rs"
+
 [profile.release]
 lto = true      # Enable link-time optimizations
 strip = true    # Strip symbols from the binary
@@ -28,11 +32,14 @@ anyhow = "1.0.75"
 byteorder = "1.5.0"
 expanduser = "1.2.2"
 libc = "0.2.149"
-log = "0.4.20"
+nix = { version = "0.27.1", features = ["signal"] }
 rust-ini = "0.19.0"
+sd-listen-fds = "0.2.0"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
 tokio = { version = "1.33.0", features = ["full"] }
 tokio-fd = "0.3.0"
+tokio-util = "0.7.9"
 toml = "0.8.2"
-tracing-subscriber = "0.3.17"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,69 @@
+#!/bin/sh -e
+
+if [ "$#" -eq 0 ]; then
+	cat <<-EOF
+		Usage: $0 <browser>...
+		<browser> refers to the name of a browser entry in the configuration file of
+		the nm-proxy daemon. Examples include "firefox", "librewolf", and "chromium".
+	EOF
+
+	exit 1
+fi
+
+rustup target add x86_64-unknown-linux-musl
+cargo build --release
+
+DAEMON_PATH=$(readlink -f target/x86_64-unknown-linux-musl/release/daemon)
+SETUP_PATH=$(readlink -f target/x86_64-unknown-linux-musl/release/setup)
+
+cat >~/.config/systemd/user/nm-proxy-setup.service <<EOF
+[Unit]
+Description=nm-proxy setup helper
+
+[Service]
+#Environment=RUST_LOG=trace
+ExecStart="$SETUP_PATH"
+
+[Install]
+WantedBy=default.target
+EOF
+
+cat >~/.config/systemd/user/nm-proxy.service <<EOF
+[Unit]
+Description=nm-proxy daemon
+
+[Service]
+#Environment=RUST_LOG=trace
+ExecStart="$DAEMON_PATH"
+KillSignal=SIGINT
+NonBlocking=true
+EOF
+
+# The ListenStreams can't be touched after the socket services have been started without losing the FDs
+cat >~/.config/systemd/user/nm-proxy@.socket <<EOF
+[Unit]
+Description=nm-proxy daemon sockets
+
+[Socket]
+Service=nm-proxy.service
+ListenStream=%t/nm-proxy-%I.socket
+FileDescriptorName=%I
+
+[Install]
+WantedBy=sockets.target
+EOF
+
+for browser in "$@"; do
+	systemctl --user stop "nm-proxy@$browser.socket"
+done
+
+systemctl --user stop nm-proxy.service
+systemctl --user daemon-reload
+
+systemctl --user enable nm-proxy-setup.service
+systemctl --user start nm-proxy-setup.service
+
+for browser in "$@"; do
+	systemctl --user enable "nm-proxy@$browser.socket"
+	systemctl --user start "nm-proxy@$browser.socket"
+done

--- a/src/common/constants.rs
+++ b/src/common/constants.rs
@@ -1,0 +1,10 @@
+// (c) Dennis Marttinen 2023
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pub const SOCKET_PREFIX: &str = "nm-proxy-";
+pub const SOCKET_SUFFIX: &str = ".socket";
+pub const CONFIG_DIR: &str = "nm-proxy";
+pub const CONFIG_FILE: &str = "config.toml";
+pub const APP_MANIFEST_DIR: &str = "manifest";
+pub const PROXY_CLIENT_BIN: &str = "nm-proxy-client";
+pub const SETTINGS_FILE_NAME: &str = "nm-proxy-settings.toml";

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -13,13 +13,9 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
-pub const SOCKET_PREFIX: &str = "nm-proxy-";
-pub const EXTENSION_KEY: &str = "extension";
-pub const CONFIG_DIR: &str = "nm-proxy";
-pub const CONFIG_FILE: &str = "config.toml";
-pub const APP_MANIFEST_DIR: &str = "manifest";
-pub const PROXY_CLIENT_BIN: &str = "nm-proxy-client";
-
+pub mod config;
+pub mod constants;
+pub mod runtime;
 pub mod traits;
 
 #[derive(Serialize, Deserialize)]

--- a/src/common/runtime/mod.rs
+++ b/src/common/runtime/mod.rs
@@ -1,0 +1,21 @@
+// (c) Dennis Marttinen 2023
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use anyhow::{anyhow, bail, Result};
+use std::env;
+
+pub mod settings;
+pub use settings::*;
+
+pub async fn parse_runtime_dir(context: &str) -> Result<String> {
+    let mut args = env::args();
+    let invocation_path = args
+        .next()
+        .ok_or(anyhow!("Unable to acquire invocation path"))?;
+
+    if let (Some(dir), None) = (args.next(), args.next()) {
+        return Ok(dir);
+    }
+
+    bail!("Usage: {} <runtime-dir>\n{}", invocation_path, context);
+}

--- a/src/common/runtime/settings.rs
+++ b/src/common/runtime/settings.rs
@@ -1,0 +1,42 @@
+// (c) Dennis Marttinen 2023
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::common::constants::*;
+use anyhow::Result;
+use anyhow::{Context, Error};
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::Path;
+use tokio::fs;
+use tracing::instrument;
+
+pub type NativeBinaryMap = HashMap<String, HashMap<String, String>>;
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)] // Strict mode
+pub struct Settings {
+    pub native_binaries: NativeBinaryMap,
+}
+
+impl Settings {
+    #[instrument(level = "info", skip(dir), fields(dir = %dir.as_ref().display()))]
+    pub async fn save(&self, dir: impl AsRef<Path>) -> Result<()> {
+        fs::write(
+            dir.as_ref().join(SETTINGS_FILE_NAME),
+            &toml::to_string_pretty(self).context("Failed to serialize runtime settings")?,
+        )
+        .await
+        .map_err(|e| Error::from(e).context("Failed to write runtime settings"))
+    }
+
+    #[instrument(level = "info", skip(dir), fields(dir = %dir.as_ref().display()))]
+    pub async fn load(dir: impl AsRef<Path>) -> Result<Self> {
+        toml::from_str(
+            &fs::read_to_string(dir.as_ref().join(SETTINGS_FILE_NAME))
+                .await
+                .map_err(|e| Error::from(e).context("Failed to read runtime settings"))?,
+        )
+        .context("Failed to deserialize runtime settings")
+    }
+}

--- a/src/common/traits/error.rs
+++ b/src/common/traits/error.rs
@@ -1,0 +1,48 @@
+// (c) Dennis Marttinen 2023
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use anyhow::{Context, Result};
+use std::fs::{FileType, Metadata};
+use std::io::Result as IoResult;
+use std::path::Path;
+use tokio::fs::{DirEntry, ReadDir};
+use tokio::net::UnixListener;
+
+pub trait ErrorContext<T> {
+    fn path_context(self, path: impl AsRef<Path>) -> Result<T>;
+}
+
+impl ErrorContext<Metadata> for IoResult<Metadata> {
+    fn path_context(self, path: impl AsRef<Path>) -> Result<Metadata> {
+        self.with_context(|| path.as_ref().display().to_string())
+            .context("Unable to read metadata")
+    }
+}
+
+impl ErrorContext<FileType> for IoResult<FileType> {
+    fn path_context(self, path: impl AsRef<Path>) -> Result<FileType> {
+        self.with_context(|| path.as_ref().display().to_string())
+            .context("Unable to file type")
+    }
+}
+
+impl ErrorContext<Option<DirEntry>> for IoResult<Option<DirEntry>> {
+    fn path_context(self, path: impl AsRef<Path>) -> Result<Option<DirEntry>> {
+        self.with_context(|| path.as_ref().display().to_string())
+            .context("Unable to access directory entry")
+    }
+}
+
+impl ErrorContext<ReadDir> for IoResult<ReadDir> {
+    fn path_context(self, path: impl AsRef<Path>) -> Result<ReadDir> {
+        self.with_context(|| path.as_ref().display().to_string())
+            .context("Unable to read directory")
+    }
+}
+
+impl ErrorContext<UnixListener> for IoResult<UnixListener> {
+    fn path_context(self, path: impl AsRef<Path>) -> Result<UnixListener> {
+        self.with_context(|| path.as_ref().display().to_string())
+            .context("Failed bind to socket")
+    }
+}

--- a/src/common/traits/mod.rs
+++ b/src/common/traits/mod.rs
@@ -1,5 +1,8 @@
 // (c) Dennis Marttinen 2023
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+mod error;
 mod path;
+
+pub use error::*;
 pub use path::*;

--- a/src/common/traits/path.rs
+++ b/src/common/traits/path.rs
@@ -12,7 +12,7 @@ pub trait OsStringIntoString {
 impl OsStringIntoString for OsString {
     fn into_string_result(self) -> Result<String> {
         self.into_string()
-            .map_err(|s| anyhow!("Failed to parse path as string").context(format!("{:?}", s)))
+            .map_err(|s| anyhow!("{:?}", s).context("Failed to parse OS string as String"))
     }
 }
 

--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -1,78 +1,134 @@
 // (c) Dennis Marttinen 2023
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use anyhow::{anyhow, Context, Result};
+use libc::pid_t;
+use nix::sys::signal;
+use nix::sys::signal::Signal;
+use nix::unistd::Pid;
 use std::collections::HashMap;
-use std::io::{BufRead, Read};
-use std::os::fd::{AsFd, AsRawFd};
-use std::pin::Pin;
+use std::fmt::Debug;
 use std::process::Stdio;
 use std::sync::Arc;
-use std::task::Poll;
-
-use anyhow::{anyhow, Context, Error, Result};
-use log::{debug, error, info, warn};
-use nm_proxy::common::{recv_nm_object, HandshakeMessage};
-use tokio::io::{copy, AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, BufReader};
+use tokio::io::{copy, AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::net::UnixStream;
-use tokio::process::{ChildStderr, Command};
+use tokio::process::Command;
+use tokio::select;
 use tokio::task::JoinSet;
-use tokio_fd::AsyncFd;
+use tokio::time;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, instrument, warn};
+
+use nm_proxy::common::{recv_nm_object, HandshakeMessage};
 
 pub struct ClientTaskConfig {
+    pub browser: String,
     pub stream: UnixStream,
     pub bin_map: Arc<HashMap<String, String>>,
+    pub token: CancellationToken,
 }
 
 impl ClientTaskConfig {
-    pub async fn launch(self) {
-        match launch_tasks(self).await {
-            Ok(_) => info!("task complete"),
-            Err(e) => error!("task crash:\n{:?}", e),
-        };
+    #[instrument(skip_all, fields(id = _id, browser = self.browser, manifest), err)]
+    pub(crate) async fn launch(self, _id: u32) -> Result<()> {
+        info!("waiting for handshake");
+        let (mut stream_rx, mut stream_tx) = self.stream.into_split();
+        let handshake: HandshakeMessage = recv_nm_object(&mut stream_rx)
+            .await
+            .context("Receiving handshake message failed")?;
+
+        // Register the manifest name into the instrumentation
+        tracing::Span::current().record("manifest", &handshake.manifest_name);
+        info!("client connected");
+
+        let binary = self.bin_map.get(&handshake.manifest_name).ok_or(anyhow!(
+            "Native binary for {} not registered",
+            handshake.manifest_name
+        ))?;
+
+        info!("launching native binary: {}", binary);
+        debug!("handshake args: {:?}", handshake.args);
+
+        // Start the native binary as a subprocess
+        let mut child = Command::new(binary)
+            .args(handshake.args) // Pass through the arguments from the browser
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let mut child_stdin = child.stdin.take().unwrap();
+        let mut child_stdout = child.stdout.take().unwrap();
+
+        let child_stderr = child.stderr.take().unwrap();
+        let binary_clone = binary.clone();
+
+        // This will abort all nested tasks when dropped
+        let mut set = JoinSet::new();
+        set.spawn(async move { copy(&mut child_stdout, &mut stream_tx).await.map(|_| ()) });
+        set.spawn(async move { copy(&mut stream_rx, &mut child_stdin).await.map(|_| ()) });
+        set.spawn(
+            async move { stderr_task(child_stderr, _id, &self.browser, &*binary_clone).await },
+        );
+
+        // Dummy task for triggering cancellation
+        set.spawn(async move {
+            self.token.cancelled().await;
+            Ok(())
+        });
+
+        let mut aborted = false;
+        while let Some(a) = set.join_next().await {
+            match a {
+                Ok(Ok(_)) => (),
+                Ok(Err(e)) => Err(e).context("IO task error")?,
+                Err(e) if e.is_cancelled() => (), // Cancellations are expected
+                Err(e) => Err(e).context("IO task join failed")?,
+            }
+
+            if !aborted {
+                aborted = true;
+
+                // Give the application a little time to react to stdio being closed
+                time::sleep(time::Duration::from_millis(200)).await;
+
+                // Send SIGTERM to native binary (regardless of task that quit)
+                if let Some(id) = child.id() {
+                    signal::kill(Pid::from_raw(id as pid_t), Signal::SIGTERM).unwrap();
+                }
+
+                // Wait for 10 seconds for the process to quit
+                select! {
+                    _ = time::sleep(time::Duration::from_secs(10)) => {
+                        warn!("timeout reached, killing {binary}");
+                        child.kill().await.with_context(|| format!("failed to kill {binary}"))?;
+                    }
+                    res = child.wait() => {
+                        match res {
+                            Ok(s) => info!("{binary}: {s}"),
+                            Err(e) => Err(e)
+                                .with_context(|| format!("{binary}: unclean shutdown"))?
+                        };
+                    }
+                }
+
+                // Abort all IO tasks after first task has finished
+                set.abort_all();
+            }
+        }
+
+        Ok(())
     }
 }
 
-async fn launch_tasks(mut config: ClientTaskConfig) -> Result<()> {
-    let (mut stream_rx, mut stream_tx) = config.stream.into_split();
-    let handshake: HandshakeMessage = recv_nm_object(&mut stream_rx)
-        .await
-        .context("Receiving handshake message failed")?;
-
-    info!("client for {} connected", handshake.manifest_name);
-    debug!("handshake args: {:?}", handshake.args);
-
-    let binary = config.bin_map.get(&handshake.manifest_name).ok_or(anyhow!(
-        "Native binary for {} not registered",
-        handshake.manifest_name
-    ))?;
-
-    // Start your target application as a subprocess
-    let mut child = Command::new(binary)
-        .args(handshake.args) // Pass through the arguments from the browser
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-
-    let mut child_stdin = child.stdin.take().unwrap();
-    let mut child_stdout = child.stdout.take().unwrap();
-    let mut child_stderr = child.stderr.take().unwrap();
-
-    // This will abort all nested tasks when dropped
-    let mut set = JoinSet::new();
-    set.spawn(async move { copy(&mut child_stdout, &mut stream_tx).await.map(|_| ()) });
-    set.spawn(async move { copy(&mut stream_rx, &mut child_stdin).await.map(|_| ()) });
-    set.spawn(async move { stderr_task(child_stderr).await.map(|_| ()) });
-
-    // TODO: Process the JoinSet output
-    // TODO: Handle SIGTERM
-    while let Some(_) = set.join_next().await {}
-
-    Ok(())
-}
-
-/// Prints warning messages from stderr of child process
-async fn stderr_task(mut stderr: impl AsyncRead + Unpin) -> std::io::Result<()> {
+/// Prints warning messages from stderr of a child process
+#[instrument(skip_all, fields(id = _id, browser = _browser, binary = _binary))]
+async fn stderr_task(
+    stderr: impl AsyncRead + Unpin + Debug,
+    _id: u32,
+    _browser: &str,
+    _binary: &str,
+) -> std::io::Result<()> {
     let mut buf = String::new();
     let mut reader = BufReader::new(stderr);
 
@@ -80,7 +136,8 @@ async fn stderr_task(mut stderr: impl AsyncRead + Unpin) -> std::io::Result<()> 
         match reader.read_line(&mut buf).await {
             Ok(0) => return Ok(()), // Closed
             Ok(_) => {
-                buf.pop(); // Remove newline
+                buf.pop();
+                // Remove newline
                 warn!("task error: {}", buf);
                 buf.clear(); // Clear buffer for next message
             }

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -2,265 +2,179 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use crate::client::ClientTaskConfig;
-use crate::config::Config;
 use anyhow::{anyhow, bail, Context, Error, Result};
-use ini::Error::Io;
-use ini::Ini;
-use log::{debug, error, info};
-use nm_proxy::common;
-use nm_proxy::common::traits::*;
-use nm_proxy::common::SOCKET_PREFIX;
-use serde_json::Value;
 use std::collections::HashMap;
-use std::env;
-use std::ffi::{OsStr, OsString};
-use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+use std::os::fd::OwnedFd;
+use std::os::unix::net as std_net;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
-use tokio::io::AsyncReadExt;
+use tokio::net::UnixListener;
 use tokio::task::JoinSet;
-use tokio::{fs, net};
+use tokio::{select, signal};
+use tokio_util::sync::CancellationToken;
+use tracing::instrument;
+use tracing::{error, info};
+
+use nm_proxy::common;
+use nm_proxy::common::runtime::Settings;
+use nm_proxy::common::traits::*;
 
 mod client;
-mod config;
 
-fn set_socket_path_override(name: &str, config: &mut Ini) {
-    let filesystems = config
-        .section(Some("Context"))
-        .map(|s| s.get("filesystems"))
-        .flatten()
-        .unwrap_or("")
-        .to_owned();
-
-    let socket_path = format!("xdg-run/{SOCKET_PREFIX}{name}");
-    if filesystems.split(";").any(|e| e == socket_path) {
-        return; // Already configured
-    }
-
-    config.with_section(Some("Context")).set(
-        "filesystems",
-        if filesystems.is_empty() {
-            socket_path
-        } else {
-            format!("{filesystems};{socket_path}")
-        },
-    );
+#[instrument(level = "debug", ret)]
+async fn parse_sockets() -> Result<HashMap<String, OwnedFd>> {
+    Ok(sd_listen_fds::get()
+        .context("Socket parsing failed")?
+        .into_iter()
+        .map(|(name, fd)| {
+            let std_fd = fd.into_std();
+            match name {
+                None => Err(anyhow!("No name provided for fd {:?}", std_fd)),
+                Some(n) => Ok((n, std_fd)),
+            }
+        })
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .collect())
 }
 
-type NativeBinaryMap = HashMap<String, HashMap<String, String>>;
-
-async fn install_manifest(entry: &fs::DirEntry, nmh_dir: &Path) -> Result<String> {
-    let file_name = entry.file_name().into_string_result()?;
-    let mut app_manifest = fs::File::open(entry.path()).await?;
-    let mut contents = String::new();
-    app_manifest.read_to_string(&mut contents).await?;
-    let mut contents: Value = serde_json::from_str(&contents)?;
-
-    let path = if let Value::String(path) = &contents["path"] {
-        path.into()
-    } else {
-        bail!("Malformed app manifest, \"path\" key missing");
-    };
-
-    match &contents["type"] {
-        Value::String(s) if s == "stdio" => (),
-        _ => bail!("Unsupported app manifest, only type \"stdio\" is currently supported"),
-    }
-
-    // Replace the path with the proxy client path
-    contents["path"] = nmh_dir
-        .join(common::PROXY_CLIENT_BIN)
-        .into_string_result()?
-        .into();
-
-    // Write the modified app manifest into the NMH directory
-    fs::write(
-        nmh_dir.join(file_name),
-        serde_json::to_vec_pretty(&contents)?,
-    )
-    .await?;
-    Ok(path)
+struct ListenerConfig {
+    browser: String,
+    listener: UnixListener,
+    bin_map_arc: Arc<HashMap<String, String>>,
+    task_id_gen: Arc<AtomicU32>,
+    token: CancellationToken,
 }
 
-async fn read_manifests(config: &Config) -> Result<NativeBinaryMap> {
-    let mut manifest_dir = config::form_config_path().await?;
-    manifest_dir.push(common::APP_MANIFEST_DIR);
+impl ListenerConfig {
+    #[instrument(skip_all, fields(browser = self.browser))]
+    async fn spawn_listener(self) -> Result<()> {
+        info!("listening for incoming native messaging connections");
 
-    let mut native_binary_map = NativeBinaryMap::new();
+        // This will abort all nested tasks when dropped
+        let mut client_set = JoinSet::new();
 
-    // TODO: This should output some help text related to
-    //  installing manifests if the directory is absent
-    let mut stream = fs::read_dir(&manifest_dir)
-        .await
-        .with_context(|| format!("Failed to read {}", manifest_dir.display()))?;
-
-    while let Some(entry) = stream
-        .next_entry()
-        .await
-        .with_context(|| format!("Failed to access entry in {}", manifest_dir.display()))?
-    {
-        let metadata = entry.metadata().await?;
-        let file_name = entry.file_name().into_string_result()?;
-        if !metadata.is_file() || !file_name.ends_with(".json") {
-            continue; // Skip all entries that are not app manifests
-        }
-
-        for (browser, nmh_dir) in config.nmh_dirs()? {
-            let mut browser_manifest = manifest_dir.join(browser);
-            browser_manifest.push(&file_name);
-            match fs::metadata(&browser_manifest).await {
-                // If an equivalent browser-specific manifest exists, it has precedence
-                Ok(m) if m.is_file() => continue,
-                Ok(m) => bail!("Expected file, found {:?}", m.file_type()),
-                Err(e) if e.kind() == ErrorKind::NotFound => (),
-                result @ Err(_) => result.map(|_| ()).with_context(|| {
-                    format!("Unable to read metadata of {}", browser_manifest.display())
-                })?,
-            }
-
-            let nmh_path = install_manifest(&entry, &nmh_dir).await?;
-
-            // Track native binary paths per browser for host-side execution
-            native_binary_map
-                .entry(browser.into())
-                .or_insert(Default::default())
-                .insert(file_name.clone(), nmh_path);
-        }
-    }
-
-    for (browser, nmh_dir) in config.nmh_dirs()? {
-        let browser_manifest_dir = manifest_dir.join(browser);
-        let mut stream = match fs::read_dir(&browser_manifest_dir).await {
-            Ok(s) => s,
-            Err(e) if e.kind() == ErrorKind::NotFound => continue, // Skip if not found
-            result @ Err(_) => {
-                result.with_context(|| format!("Failed to read {}", manifest_dir.display()))?
-            }
-        };
-
-        while let Some(entry) = stream
-            .next_entry()
-            .await
-            .with_context(|| format!("Failed to access entry in {}", manifest_dir.display()))?
-        {
-            let metadata = entry.metadata().await?;
-            let file_name = entry.file_name().into_string_result()?;
-            if !metadata.is_file() || !file_name.ends_with(".json") {
-                continue; // Skip all entries that are not app manifests
-            }
-
-            let nmh_path = install_manifest(&entry, &nmh_dir).await?;
-
-            // Track native binary paths per browser for host-side execution
-            native_binary_map
-                .entry(browser.into())
-                .or_insert(Default::default())
-                .insert(file_name, nmh_path);
-        }
-    }
-
-    Ok(native_binary_map)
-}
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Initialize logging framework
-    tracing_subscriber::fmt::init();
-
-    // Parse this early for early error
-    let runtime_dir = PathBuf::from(common::parse_env("XDG_RUNTIME_DIR", None)?);
-
-    // Load configuration
-    let config = config::load_config().await?;
-
-    for (_, nmh_dir) in config.nmh_dirs()? {
-        // Create native messaging host directory
-        match fs::create_dir(&nmh_dir).await {
-            Ok(_) => (),
-            Err(e) if e.kind() == ErrorKind::AlreadyExists => (),
-            result @ Err(_) => result
-                .with_context(|| format!("{}", nmh_dir.display()))
-                .context("Unable to create NMH directory, is the browser configuration correct?")?,
-        }
-
-        // Install proxy client
-        let proxy_client_src = config.proxy_client_path();
-        let proxy_client_dest = nmh_dir.join(common::PROXY_CLIENT_BIN);
-        fs::copy(&proxy_client_src, &proxy_client_dest)
-            .await
-            .with_context(|| format!("{}", proxy_client_src.display()))
-            .with_context(|| {
-                format!(
-                    "Unable to copy proxy client to {}",
-                    proxy_client_dest.display()
-                )
-            })?;
-    }
-
-    let native_binary_map = read_manifests(&config).await?;
-
-    // Configure Flatpak overrides
-    for (name, path) in config.override_paths()? {
-        let mut ini = match Ini::load_from_file(&path) {
-            Ok(i) => i,
-            Err(Io(e)) if e.kind() == ErrorKind::NotFound => Ini::new(),
-            result @ Err(_) => result
-                .with_context(|| format!("{}", path.display()))
-                .with_context(|| format!("Unable to read Flatpak overrides for {name}"))?,
-        };
-
-        set_socket_path_override(name, &mut ini);
-        ini.write_to_file(&path)
-            .with_context(|| format!("{}", path.display()))
-            .with_context(|| format!("Unable to update Flatpak overrides for {name}"))?;
-    }
-
-    debug!("configuration: {:?}", config);
-    debug!("native binary map: {:?}", native_binary_map);
-
-    let mut set = JoinSet::new();
-
-    for (browser, binary_map) in native_binary_map {
-        let socket_path = runtime_dir.join(format!("{SOCKET_PREFIX}{browser}"));
-        match fs::remove_file(&socket_path).await {
-            Ok(_) => (),
-            Err(e) if e.kind() == ErrorKind::NotFound => (),
-            result @ Err(_) => {
-                result.with_context(|| format!("Failed to remove {}", socket_path.display()))?
-            }
-        }
-
-        let listener = net::UnixListener::bind(&socket_path)
-            .with_context(|| format!("Failed bind socket {}", socket_path.display()))?;
-
-        let binary_map_arc = Arc::new(binary_map);
-
-        set.spawn(async move {
-            info!("Listening on {}", socket_path.display());
-
-            // This will abort all nested tasks when dropped
-            let mut client_set = JoinSet::new();
-
-            loop {
-                match listener.accept().await {
-                    Ok((stream, _)) => {
-                        let bin_map = binary_map_arc.clone();
-                        client_set.spawn(async move {
-                            ClientTaskConfig { stream, bin_map }.launch().await;
-                        });
-                    }
-                    Err(e) => {
-                        error!("Error accepting client: {}", e);
+        loop {
+            select! {
+                _ = self.token.cancelled() => { break }
+                res = self.listener.accept() => {
+                    match res {
+                        Ok((stream, _)) => {
+                            let browser = self.browser.clone();
+                            let bin_map = self.bin_map_arc.clone();
+                            let id = self.task_id_gen.fetch_add(1, Ordering::Relaxed);
+                            let token = self.token.clone();
+                            client_set.spawn(async move {
+                                let res = ClientTaskConfig {
+                                    browser,
+                                    stream,
+                                    bin_map,
+                                    token,
+                                }
+                                .launch(id)
+                                .await;
+                                res
+                            });
+                        }
+                        Err(e) => {
+                            error!("error accepting client: {e}");
+                        }
                     }
                 }
             }
+        }
 
-            // TODO: We can handle the client task output here if needed
+        while let Some(result) = client_set.join_next().await {
+            match result {
+                Ok(Ok(_)) => (),
+                Ok(Err(e)) => Err(e).context("client task error")?,
+                Err(e) => Err(e).context("client task join failed")?,
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[tokio::main]
+#[instrument]
+async fn main() -> Result<()> {
+    // Initialize the logging framework
+    tracing_subscriber::fmt::init();
+
+    // Parse sockets passed by systemd
+    let mut sockets = parse_sockets().await?;
+    if sockets.is_empty() {
+        bail!("The daemon must be launched as a systemd socket-activated service");
+    }
+
+    // Acquire the runtime directory path
+    let runtime_dir = common::parse_env("XDG_RUNTIME_DIR", None)?;
+
+    // Load runtime settings
+    let settings = Settings::load(&runtime_dir).await?;
+
+    let mut set = JoinSet::new();
+    let task_id = Arc::new(AtomicU32::new(0));
+    let token = CancellationToken::new();
+
+    for (browser, bin_map) in settings.native_binaries {
+        // Retrieve fd from socket configuration
+        let fd = match sockets.remove(&browser) {
+            Some(fd) => fd,
+            None => {
+                return Err(anyhow!("{}: socket not found", browser).context(
+                    r"
+Expected socket from systemd, but it is absent. Check
+ListenStream/FileDescriptorName entries in socket unit(s)",
+                ));
+            }
+        };
+
+        // Construct UNIX socket listener
+        let listener =
+            UnixListener::from_std(std_net::UnixListener::from(fd)).path_context(&browser)?;
+
+        // These need to have distributed access since Tokio tasks can't be scoped
+        let bin_map_arc = Arc::new(bin_map);
+        let task_id_gen = task_id.clone();
+        let token = token.clone();
+
+        set.spawn(async move {
+            ListenerConfig {
+                browser,
+                listener,
+                bin_map_arc,
+                task_id_gen,
+                token,
+            }
+            .spawn_listener()
+            .await
         });
     }
 
-    // TODO: Handle responses from tasks here
-    while let Some(_) = set.join_next().await {}
+    // Graceful shutdown helper task
+    set.spawn(async move {
+        signal::ctrl_c()
+            .await
+            .map_err(|e| Error::from(e).context("Failed to wait for SIGINT"))
+    });
 
+    // Handle responses from tasks
+    let mut aborted = false;
+    while let Some(result) = set.join_next().await {
+        match result {
+            Ok(Ok(_)) => (),
+            Ok(Err(e)) => Err(e).context("listener task error")?,
+            Err(e) => Err(e).context("listener task join failed")?,
+        }
+
+        if !aborted {
+            aborted = true;
+            token.cancel(); // Begin graceful shutdown
+        }
+    }
+
+    info!("graceful shutdown");
     Ok(())
 }

--- a/src/setup/help.rs
+++ b/src/setup/help.rs
@@ -1,0 +1,23 @@
+// (c) Dennis Marttinen 2023
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+pub trait ManifestHelpContext {
+    fn manifest_help_context(self, manifest_dir: impl AsRef<Path>) -> Self;
+}
+
+impl<T> ManifestHelpContext for Result<T> {
+    fn manifest_help_context(self, manifest_dir: impl AsRef<Path>) -> Self {
+        self.with_context(|| format!(
+            r#"
+No manifests found. In order to use nm-proxy, please place (unmodified) app manifests [1] in the manifest directory at
+{},
+optionally in a sub-directory named after a browser configuration (e.g., "firefox") to scope it to a particular browser.
+
+[1]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#app_manifest"#,
+            manifest_dir.as_ref().display())
+        )
+    }
+}

--- a/src/setup/main.rs
+++ b/src/setup/main.rs
@@ -1,0 +1,276 @@
+// (c) Dennis Marttinen 2023
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use anyhow::{bail, Context, Result};
+use ini::Error::Io;
+use ini::Ini;
+use serde_json::Value;
+use std::io::ErrorKind;
+use std::path::Path;
+use tokio::fs;
+use tokio::fs::DirEntry;
+use tokio::io::AsyncReadExt;
+use tracing::{debug, info, instrument};
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::EnvFilter;
+
+use nm_proxy::common;
+use nm_proxy::common::config;
+use nm_proxy::common::config::Config;
+use nm_proxy::common::constants::*;
+use nm_proxy::common::runtime::{NativeBinaryMap, Settings};
+use nm_proxy::common::traits::*;
+
+mod help;
+
+use help::ManifestHelpContext;
+
+#[instrument(skip(nmh_dir), fields(browser = _browser, nmh_dir = %nmh_dir.as_ref().display()))]
+async fn create_nmh_dir(_browser: &str, nmh_dir: impl AsRef<Path>) -> Result<()> {
+    let nmh_dir = nmh_dir.as_ref();
+
+    match fs::create_dir(nmh_dir).await {
+        Ok(_) => (),
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => (),
+        result @ Err(_) => result
+            .with_context(|| format!("{}", nmh_dir.display()))
+            .context("Unable to create NMH directory, is the browser configuration correct?")?,
+    }
+
+    Ok(())
+}
+
+#[instrument(skip(nmh_dir, config), fields(nmh_dir = %nmh_dir.as_ref().display()))]
+async fn install_proxy_client(
+    browser: &str,
+    nmh_dir: impl AsRef<Path>,
+    config: &Config,
+) -> Result<()> {
+    let nmh_dir = nmh_dir.as_ref();
+    let proxy_client_src = config.proxy_client_path();
+    let proxy_client_dest = nmh_dir.join(PROXY_CLIENT_BIN);
+
+    fs::copy(&proxy_client_src, &proxy_client_dest)
+        .await
+        .with_context(|| {
+            format!(
+                "{} -> {}",
+                proxy_client_src.display(),
+                proxy_client_dest.display()
+            )
+        })
+        .with_context(|| format!("{}: unable to copy proxy client", browser))?;
+
+    Ok(())
+}
+
+#[instrument(skip(path), fields(path = %path.as_ref().display()))]
+async fn configure_flatpak_overrides(browser: &str, path: impl AsRef<Path>) -> Result<()> {
+    let path = path.as_ref();
+    let mut ini = match Ini::load_from_file(&path) {
+        Ok(i) => i,
+        Err(Io(e)) if e.kind() == ErrorKind::NotFound => Ini::new(),
+        result @ Err(_) => result
+            .with_context(|| path.display().to_string())
+            .with_context(|| format!("Unable to read Flatpak overrides for {browser}"))?,
+    };
+
+    set_socket_path_override(browser, &mut ini);
+    ini.write_to_file(&path)
+        .with_context(|| path.display().to_string())
+        .with_context(|| format!("Unable to update Flatpak overrides for {browser}"))?;
+
+    Ok(())
+}
+
+#[instrument(level = "trace", skip(path), fields(path = %path.as_ref().display()))]
+async fn read_manifest(path: impl AsRef<Path>) -> Result<Value> {
+    let mut contents = String::new();
+    fs::File::open(path)
+        .await?
+        .read_to_string(&mut contents)
+        .await?;
+
+    Ok(serde_json::from_str(&contents)?)
+}
+
+#[instrument(skip_all, fields(browser = _browser, path = %entry.path().display()))]
+async fn install_manifest(entry: &DirEntry, _browser: &str, nmh_dir: &Path) -> Result<String> {
+    // Read the manifest
+    let path = entry.path();
+    let mut manifest = read_manifest(&path)
+        .await
+        .with_context(|| path.display().to_string())
+        .context("Unable to read app manifest")?;
+
+    // Extract the "path" field
+    let path = match &manifest["path"] {
+        Value::String(s) => s.into(),
+        _ => bail!("Malformed app manifest, \"path\" key missing"),
+    };
+
+    // Check that the "type" field is "stdio" (other formats are currently unsupported)
+    match &manifest["type"] {
+        Value::String(s) if s == "stdio" => (),
+        _ => bail!("Unsupported app manifest, only type \"stdio\" is currently supported"),
+    }
+
+    // Replace the path with the proxy client path
+    manifest["path"] = nmh_dir.join(PROXY_CLIENT_BIN).into_string_result()?.into();
+
+    // Write the modified app manifest into the NMH directory
+    let deployment_path = nmh_dir.join(entry.file_name());
+    fs::write(&deployment_path, serde_json::to_vec_pretty(&manifest)?)
+        .await
+        .with_context(|| deployment_path.display().to_string())
+        .context("Failed to deploy app manifest")?;
+    Ok(path)
+}
+
+#[instrument(level = "trace", skip_all)]
+async fn install_manifests(config: &Config, path: impl AsRef<Path>) -> Result<NativeBinaryMap> {
+    let manifest_dir = path.as_ref().join(APP_MANIFEST_DIR);
+
+    // Open the manifest directory as a stream
+    let mut stream = match fs::read_dir(&manifest_dir).await {
+        Ok(s) => s,
+        result @ Err(_) => {
+            let kind = result.as_ref().err().map(|e| e.kind());
+            let result = result.path_context(&manifest_dir);
+            match kind {
+                Some(ErrorKind::NotFound) => result.manifest_help_context(&manifest_dir),
+                _ => result,
+            }?
+        }
+    };
+
+    let mut native_binary_map = NativeBinaryMap::new();
+
+    // Install common manifests
+    while let Some(entry) = stream.next_entry().await.path_context(&manifest_dir)? {
+        let metadata = entry.metadata().await.path_context(entry.path())?;
+        let file_name = entry.file_name().into_string_result()?;
+        if !metadata.is_file() || !file_name.ends_with(".json") {
+            continue; // Skip all entries that are not app manifests
+        }
+
+        for (browser, nmh_dir) in config.nmh_dirs()? {
+            let mut browser_manifest = manifest_dir.join(browser);
+            browser_manifest.push(&file_name);
+            match fs::metadata(&browser_manifest).await {
+                // If an equivalent browser-specific manifest exists, it has precedence
+                Ok(m) if m.is_file() => continue,
+                Ok(m) => bail!("Expected file, found {:?}", m.file_type()),
+                Err(e) if e.kind() == ErrorKind::NotFound => (),
+                result @ Err(_) => result.path_context(&browser_manifest).map(|_| ())?,
+            }
+
+            // Install the manifest
+            let nmh_path = install_manifest(&entry, browser, &nmh_dir).await?;
+
+            // Track native binary paths per browser for host-side execution
+            native_binary_map
+                .entry(browser.into())
+                .or_insert(Default::default())
+                .insert(file_name.clone(), nmh_path);
+        }
+    }
+
+    // Install browser-specific manifests
+    for (browser, nmh_dir) in config.nmh_dirs()? {
+        let br_manifest_dir = manifest_dir.join(browser);
+        let mut stream = match fs::read_dir(&br_manifest_dir).await {
+            Ok(s) => s,
+            Err(e) if e.kind() == ErrorKind::NotFound => continue, // Skip if not found
+            result @ Err(_) => result.path_context(&br_manifest_dir)?,
+        };
+
+        while let Some(entry) = stream.next_entry().await.path_context(&br_manifest_dir)? {
+            let metadata = entry.metadata().await.path_context(entry.path())?;
+            let file_name = entry.file_name().into_string_result()?;
+            if !metadata.is_file() || !file_name.ends_with(".json") {
+                continue; // Skip all entries that are not app manifests
+            }
+
+            // Install the manifest
+            let nmh_path = install_manifest(&entry, browser, &nmh_dir).await?;
+
+            // Track native binary paths per browser for host-side execution
+            native_binary_map
+                .entry(browser.into())
+                .or_insert(Default::default())
+                .insert(file_name, nmh_path);
+        }
+    }
+
+    Ok(native_binary_map)
+}
+
+#[instrument(level = "trace", skip(config))]
+fn set_socket_path_override(browser: &str, config: &mut Ini) {
+    let filesystems = config
+        .section(Some("Context"))
+        .map(|s| s.get("filesystems"))
+        .flatten()
+        .unwrap_or("")
+        .to_owned();
+
+    let socket_path = format!("xdg-run/{SOCKET_PREFIX}{browser}{SOCKET_SUFFIX}");
+    if filesystems.split(";").any(|e| e == socket_path) {
+        return; // Already configured
+    }
+
+    config.with_section(Some("Context")).set(
+        "filesystems",
+        match &*filesystems {
+            "" => socket_path,
+            s => format!("{s};{socket_path}"),
+        },
+    );
+}
+
+#[tokio::main]
+#[instrument]
+async fn main() -> Result<()> {
+    // Initialize the logging framework
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_span_events(FmtSpan::NEW)
+        .init();
+
+    // Acquire the runtime directory path
+    let runtime_dir = common::parse_env("XDG_RUNTIME_DIR", None)?;
+
+    // Load configuration
+    let config_path = config::form_config_path().await?;
+    let config = config::load_config(&config_path).await?;
+    debug!("configuration: {:?}", config);
+
+    for (browser, nmh_dir) in config.nmh_dirs()? {
+        // Create native messaging host directory
+        create_nmh_dir(browser, &nmh_dir).await?;
+
+        // Install proxy client
+        install_proxy_client(browser, &nmh_dir, &config).await?;
+    }
+
+    // Configure Flatpak overrides
+    for (browser, path) in config.override_paths()? {
+        configure_flatpak_overrides(browser, &path).await?;
+    }
+
+    // Install manifests
+    let native_binaries = install_manifests(&config, &config_path).await?;
+    debug!("native binary map: {:?}", native_binaries);
+
+    // Save runtime configuration
+    Settings { native_binaries }.save(runtime_dir).await?;
+
+    info!("setup complete");
+    Ok(())
+}


### PR DESCRIPTION
This is a massive refactoring, bringing many new features and improving robustness and observability. Key highlights:

- A new setup binary with its own systemd service (decoupled from the daemon) to make the architecture more flexible
- systemd [socket activation](https://www.freedesktop.org/software/systemd/man/latest/systemd.socket.html)
- A new, easy-to-use installation script
- Cleaner errors thanks to a couple of new traits (`ErrorContext` in particular)
- Proper [instrumentation](https://docs.rs/tracing/latest/tracing/attr.instrument.html) thanks to [`tracing`](https://tracing.rs)
- Child process error handling and support for graceful shutdown