### PR TITLE
ci: small changes to make Dependabot compliant with Conventional Commits

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -15,6 +15,7 @@ policies:
       conventional:
         types:
           - ci
+          - deps
           - docs
           - refactor
           - release

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
Dependabot should pick up the capitalization rules based on the commit messages of its own merged commits: https://github.com/dependabot/feedback/issues/292