### PR TITLE
ci: minor fix to the Dependabot auto-merge configuration

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,4 +1,4 @@
-on: pull_request_target
+on: pull_request
 
 permissions:
   contents: write


### PR DESCRIPTION
Run on `pull_request` instead of `pull_request_target`, as described in the [official docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request).