### PR TITLE
ci: fix Dependabot commit message capitalization

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -14,8 +14,8 @@ policies:
       maximumOfOneCommit: true
       conventional:
         types:
+          - chore
           - ci
-          - deps
           - docs
           - refactor
           - release

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,4 +5,4 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "deps"
+      prefix: "chore"


### PR DESCRIPTION
Dependabot tries to be smart about when to use lowercase commit messages to comply with conventional commits, but this only works if the type is `chore`, `build` or `upgrade`: https://github.com/dependabot/dependabot-core/blob/main/common/lib/dependabot/pull_request_creator/pr_name_prefixer.rb#L158