### PR TITLE
ci: also upgrade GH Actions with Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
All of the Actions in this repo are well maintained and should be safe for automatic upgrades, this should avoid everything grinding to a halt when GitHub regularly decides to deprecate older branches of first-party Actions.